### PR TITLE
Make terminal window draggable and reset

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
 import backgroundImage from './background.png';
+import Terminal from './Terminal';
 
 function App() {
   const [currentStage, setCurrentStage] = useState('initial');
@@ -73,6 +74,8 @@ function App() {
               grow your business like a startup
             </p>
           </div>
+          {/* Add the draggable terminal */}
+          <Terminal />
         </div>
       )}
     </div>

--- a/src/Terminal.css
+++ b/src/Terminal.css
@@ -1,0 +1,220 @@
+.terminal {
+  position: fixed;
+  width: 600px;
+  height: 400px;
+  background: #1e1e1e;
+  border: 1px solid #444;
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  font-family: 'Consolas', 'Monaco', 'Courier New', monospace;
+  transition: box-shadow 0.2s ease;
+  backdrop-filter: blur(10px);
+  background: rgba(30, 30, 30, 0.95);
+}
+
+.terminal.dragging {
+  cursor: grabbing;
+  box-shadow: 0 12px 48px rgba(0, 0, 0, 0.4);
+  transform: rotate(1deg);
+  transition: none;
+}
+
+.terminal.minimized {
+  height: 40px;
+  overflow: hidden;
+}
+
+.terminal-header {
+  background: linear-gradient(135deg, #2d2d2d, #1a1a1a);
+  border-bottom: 1px solid #444;
+  padding: 8px 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: grab;
+  user-select: none;
+  border-radius: 8px 8px 0 0;
+  height: 40px;
+  box-sizing: border-box;
+}
+
+.terminal-header:active {
+  cursor: grabbing;
+}
+
+.terminal-title {
+  display: flex;
+  align-items: center;
+  color: #ffffff;
+  font-weight: 600;
+  font-size: 14px;
+}
+
+.terminal-icon {
+  margin-right: 8px;
+  font-size: 16px;
+  color: #ffd700;
+}
+
+.terminal-controls {
+  display: flex;
+  gap: 8px;
+}
+
+.terminal-button {
+  width: 16px;
+  height: 16px;
+  border: none;
+  border-radius: 50%;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: bold;
+  transition: all 0.2s ease;
+  color: #000;
+}
+
+.terminal-button.minimize {
+  background: #ffbd2e;
+}
+
+.terminal-button.minimize:hover {
+  background: #f5a623;
+}
+
+.terminal-button.close {
+  background: #ff5f56;
+}
+
+.terminal-button.close:hover {
+  background: #e04638;
+}
+
+.terminal-body {
+  height: calc(100% - 40px);
+  padding: 12px;
+  overflow-y: auto;
+  background: #1e1e1e;
+  border-radius: 0 0 8px 8px;
+}
+
+.terminal-output {
+  height: 100%;
+  color: #ffffff;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.terminal-line {
+  margin-bottom: 4px;
+}
+
+.terminal-line.info {
+  color: #00ff00;
+}
+
+.terminal-line.command {
+  color: #ffffff;
+}
+
+.terminal-line.output {
+  color: #cccccc;
+  margin-left: 0;
+  white-space: pre-wrap;
+}
+
+.terminal-line.prompt {
+  margin-bottom: 0;
+}
+
+.terminal-input-line {
+  display: flex;
+  align-items: center;
+}
+
+.terminal-prompt {
+  color: #00ff00;
+  margin-right: 8px;
+  font-weight: bold;
+}
+
+.terminal-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: #ffffff;
+  font-family: inherit;
+  font-size: inherit;
+  caret-color: #00ff00;
+}
+
+.terminal-input::placeholder {
+  color: #666;
+}
+
+/* Scrollbar styling */
+.terminal-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.terminal-body::-webkit-scrollbar-track {
+  background: #2d2d2d;
+  border-radius: 4px;
+}
+
+.terminal-body::-webkit-scrollbar-thumb {
+  background: #555;
+  border-radius: 4px;
+}
+
+.terminal-body::-webkit-scrollbar-thumb:hover {
+  background: #666;
+}
+
+/* Glow effect for active terminal */
+.terminal:hover {
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+/* Pulse animation for the terminal icon */
+.terminal-icon {
+  animation: pulse 2s ease-in-out infinite alternate;
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 0.8;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+/* Responsive design for smaller screens */
+@media (max-width: 768px) {
+  .terminal {
+    width: calc(100vw - 40px);
+    max-width: 500px;
+    height: 300px;
+  }
+}
+
+@media (max-width: 480px) {
+  .terminal {
+    width: calc(100vw - 20px);
+    height: 250px;
+    font-size: 12px;
+  }
+  
+  .terminal-title {
+    font-size: 12px;
+  }
+  
+  .terminal-output {
+    font-size: 12px;
+  }
+}

--- a/src/Terminal.js
+++ b/src/Terminal.js
@@ -1,0 +1,205 @@
+import React, { useState, useRef, useEffect } from 'react';
+import './Terminal.css';
+
+const Terminal = () => {
+  const [isDragging, setIsDragging] = useState(false);
+  const [position, setPosition] = useState({ x: 50, y: 50 }); // Default position
+  const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });
+  const [isMinimized, setIsMinimized] = useState(false);
+  const [terminalOutput, setTerminalOutput] = useState([
+    { type: 'info', text: 'Welcome to Lab Up Terminal v1.0.0' },
+    { type: 'info', text: 'Type "help" for available commands.' },
+    { type: 'prompt', text: '' }
+  ]);
+  const [currentCommand, setCurrentCommand] = useState('');
+  const terminalRef = useRef(null);
+  const inputRef = useRef(null);
+
+  // Handle mouse down on terminal header for dragging
+  const handleMouseDown = (e) => {
+    if (e.target.classList.contains('terminal-button')) return; // Don't drag when clicking buttons
+    
+    setIsDragging(true);
+    const rect = terminalRef.current.getBoundingClientRect();
+    setDragOffset({
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top
+    });
+  };
+
+  // Handle mouse move for dragging
+  const handleMouseMove = (e) => {
+    if (!isDragging) return;
+    
+    const newX = e.clientX - dragOffset.x;
+    const newY = e.clientY - dragOffset.y;
+    
+    // Keep terminal within viewport bounds
+    const maxX = window.innerWidth - 600; // Terminal width
+    const maxY = window.innerHeight - 400; // Terminal height
+    
+    setPosition({
+      x: Math.max(0, Math.min(newX, maxX)),
+      y: Math.max(0, Math.min(newY, maxY))
+    });
+  };
+
+  // Handle mouse up to stop dragging
+  const handleMouseUp = () => {
+    setIsDragging(false);
+  };
+
+  // Add global event listeners for drag functionality
+  useEffect(() => {
+    if (isDragging) {
+      document.addEventListener('mousemove', handleMouseMove);
+      document.addEventListener('mouseup', handleMouseUp);
+    }
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [isDragging, dragOffset]);
+
+  // Focus input when terminal is clicked
+  const handleTerminalClick = () => {
+    if (inputRef.current && !isMinimized) {
+      inputRef.current.focus();
+    }
+  };
+
+  // Handle command execution
+  const executeCommand = (command) => {
+    const cmd = command.trim().toLowerCase();
+    let response = '';
+
+    switch (cmd) {
+      case 'help':
+        response = `Available commands:
+  help    - Show this help message
+  clear   - Clear terminal output
+  about   - About Lab Up
+  date    - Show current date and time
+  whoami  - Display current user info
+  echo    - Echo back your message (usage: echo <message>)`;
+        break;
+      case 'clear':
+        setTerminalOutput([{ type: 'prompt', text: '' }]);
+        return;
+      case 'about':
+        response = 'Lab Up - Grow your business like a startup!\nBuilding innovative solutions for modern businesses.';
+        break;
+      case 'date':
+        response = new Date().toString();
+        break;
+      case 'whoami':
+        response = 'labup-user@terminal:~$ You are a visionary entrepreneur!';
+        break;
+      default:
+        if (cmd.startsWith('echo ')) {
+          response = command.slice(5);
+        } else if (cmd === '') {
+          response = '';
+        } else {
+          response = `Command not found: ${command}. Type 'help' for available commands.`;
+        }
+    }
+
+    // Add command and response to output
+    setTerminalOutput(prev => [
+      ...prev.slice(0, -1), // Remove the current prompt
+      { type: 'command', text: `$ ${command}` },
+      ...(response ? [{ type: 'output', text: response }] : []),
+      { type: 'prompt', text: '' }
+    ]);
+  };
+
+  // Handle input changes
+  const handleInputChange = (e) => {
+    setCurrentCommand(e.target.value);
+  };
+
+  // Handle enter key press
+  const handleInputKeyPress = (e) => {
+    if (e.key === 'Enter') {
+      executeCommand(currentCommand);
+      setCurrentCommand('');
+    }
+  };
+
+  // Terminal control buttons
+  const handleMinimize = () => {
+    setIsMinimized(!isMinimized);
+  };
+
+  const handleClose = () => {
+    // For now, just minimize instead of actually closing
+    setIsMinimized(true);
+  };
+
+  return (
+    <div
+      ref={terminalRef}
+      className={`terminal ${isMinimized ? 'minimized' : ''} ${isDragging ? 'dragging' : ''}`}
+      style={{
+        left: `${position.x}px`,
+        top: `${position.y}px`,
+      }}
+      onClick={handleTerminalClick}
+    >
+      <div className="terminal-header" onMouseDown={handleMouseDown}>
+        <div className="terminal-title">
+          <span className="terminal-icon">⚡</span>
+          Lab Up Terminal
+        </div>
+        <div className="terminal-controls">
+          <button 
+            className="terminal-button minimize" 
+            onClick={handleMinimize}
+            title={isMinimized ? "Restore" : "Minimize"}
+          >
+            {isMinimized ? '□' : '−'}
+          </button>
+          <button 
+            className="terminal-button close" 
+            onClick={handleClose}
+            title="Close"
+          >
+            ×
+          </button>
+        </div>
+      </div>
+      
+      {!isMinimized && (
+        <div className="terminal-body">
+          <div className="terminal-output">
+            {terminalOutput.map((line, index) => (
+              <div key={index} className={`terminal-line ${line.type}`}>
+                {line.type === 'prompt' ? (
+                  <div className="terminal-input-line">
+                    <span className="terminal-prompt">labup@terminal:~$ </span>
+                    <input
+                      ref={inputRef}
+                      type="text"
+                      value={currentCommand}
+                      onChange={handleInputChange}
+                      onKeyPress={handleInputKeyPress}
+                      className="terminal-input"
+                      autoFocus
+                      spellCheck={false}
+                    />
+                  </div>
+                ) : (
+                  <pre>{line.text}</pre>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Terminal;


### PR DESCRIPTION
Add a draggable terminal window that resets its position on refresh.

---
<a href="https://cursor.com/background-agent?bcId=bc-4626458b-a895-499d-b50d-287809b2cad9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4626458b-a895-499d-b50d-287809b2cad9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>